### PR TITLE
validation: replace backticks with <code> tags

### DIFF
--- a/cove_ofds/templates/cove_ofds/additional_checks_table.html
+++ b/cove_ofds/templates/cove_ofds/additional_checks_table.html
@@ -7,10 +7,10 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.span_start_node_not_found list2=additional_checks.span_end_node_not_found %}
     </h4>
     <p>
-        {% trans 'Your data contains spans with node references that cannot be resolved. `Span.start` and `Span.end` must match the `.id` of exactly one node in the `/nodes` array.'  %}
+        {% trans 'Your data contains spans with node references that cannot be resolved. <code>Span.start</code> and <code>Span.end</code> must match the <code>.id</code> of exactly one node in the <code>/nodes</code> array.'  %}
         For more information, see
-        <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Span,start">`Span.start`</a> and
-        <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Span,end">`Span.end`</a>.
+        <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Span,start"><code>Span.start</code></a> and
+        <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Span,end"><code>Span.end</code></a>.
     </p>
     <table class="table">
         <thead>
@@ -65,8 +65,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_location_type_incorrect %}
     </h4>
     <p>
-        {% trans 'Your data contains nodes with incorrect location types. `/nodes/location/type` must be `Point`.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,type">`Geometry.type`</a>.
+        {% trans 'Your data contains nodes with incorrect location types. <code>/nodes/location/type</code> must be <code>Point</code>.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,type"><code>Geometry.type</code></a>.
     </p>
     <table class="table">
         <thead>
@@ -105,8 +105,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_location_coordinates_incorrect %}
     </h4>
     <p>
-        {% trans 'Your data contains nodes with incorrectly formatted location coordinates. `/nodes/location/coordinates` must be a single position, i.e. an array of numbers.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,coordinates">`Geometry.coordinates`</a>.
+        {% trans 'Your data contains nodes with incorrectly formatted location coordinates. <code>/nodes/location/coordinates</code> must be a single position, i.e. an array of numbers.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,coordinates"><code>Geometry.coordinates</code></a>.
     </p>
     <table class="table">
         <thead>
@@ -145,8 +145,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.span_route_type_incorrect %}
     </h4>
     <p>
-        {% trans 'Your data contains spans with incorrect route types. `/spans/route/type` must be `LineString`.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,type">`Geometry.type`</a>.
+        {% trans 'Your data contains spans with incorrect route types. <code>/spans/route/type</code> must be <code>LineString</code>.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,type"><code>Geometry.type</code></a>.
     </p>
     <table class="table">
         <thead>
@@ -185,8 +185,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.span_route_coordinates_incorrect %}
     </h4>
     <p>
-        {% trans 'Your data contains spans with incorrectly formatted route coordinates. `/spans/route/coordinates` must be an array of positions, i.e. an array of arrays of numbers.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,coordinates">`Geometry.coordinates`</a>.
+        {% trans 'Your data contains spans with incorrectly formatted route coordinates. <code>/spans/route/coordinates</code> must be an array of positions, i.e. an array of arrays of numbers.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Geometry,coordinates"><code>Geometry.coordinates</code></a>.
     </p>
     <table class="table">
         <thead>
@@ -225,8 +225,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_phase_reference_id_not_found list2=additional_checks.span_phase_reference_id_not_found list3=additional_checks.contract_related_phase_reference_id_not_found %}
     </h4>
     <p>
-        {% trans 'Your data contains phase references that cannot be resolved. The `.id` of each phase reference must match the `.id` of exactly one phase in the `/phases` array.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/PhaseReference,id">`PhaseReference.id`</a>.
+        {% trans 'Your data contains phase references that cannot be resolved. The <code>.id</code> of each phase reference must match the <code>.id</code> of exactly one phase in the <code>/phases</code> array.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/PhaseReference,id"><code>PhaseReference.id</code></a>.
     </p>
     {% if 'node_phase_reference_id_not_found' in additional_checks %}
         <table class="table">
@@ -329,8 +329,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_phase_reference_name_does_not_match list2=additional_checks.span_phase_reference_name_does_not_match list3=additional_checks.contract_related_phase_reference_name_does_not_match %}
     </h4>
     <p>
-        {% trans 'Your data contains phase references with inconsistent names. The `.name` of each phase reference must match the `.name` of the phase it references.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/PhaseReference,name">`PhaseReference.name`</a>.
+        {% trans 'Your data contains phase references with inconsistent names. The <code>.name</code> of each phase reference must match the <code>.name</code> of the phase it references.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/PhaseReference,name"><code>PhaseReference.name</code></a>.
     </p>
     {% if 'node_phase_reference_name_does_not_match' in additional_checks %}
         <table class="table">
@@ -443,8 +443,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_organisation_reference_id_not_found list2=additional_checks.span_organisation_reference_id_not_found list3=additional_checks.phase_organisation_reference_id_not_found %}
     </h4>
     <p>
-        {% trans 'Your data contains organisation references that cannot be resolved. The `.id` of each organisation reference must match the `.id` of exactly one organisation in the `/organisations` array.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/OrganisationReference,id">`OrganisationReference.id`</a>.
+        {% trans 'Your data contains organisation references that cannot be resolved. The <code>.id</code> of each organisation reference must match the <code>.id</code> of exactly one organisation in the <code>/organisations</code> array.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/OrganisationReference,id"><code>OrganisationReference.id</code></a>.
     </p>
     {% if 'node_organisation_reference_id_not_found' in additional_checks %}
         <table class="table">
@@ -554,8 +554,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_organisation_reference_name_does_not_match list2=additional_checks.span_organisation_reference_name_does_not_match list3=additional_checks.phase_organisation_reference_name_does_not_match %}
     </h4>
     <p>
-        {% trans 'Your data contains organisation references with inconsistent names. The `.name` of each organisation reference must match the `.name` of the organisation it references.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/OrganisationReference,name">`OrganisationReference.name`</a>.
+        {% trans 'Your data contains organisation references with inconsistent names. The <code>.name</code> of each organisation reference must match the <code>.name</code> of the organisation it references.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/OrganisationReference,name"><code>OrganisationReference.name</code></a>.
     </p>
     {% if 'node_organisation_reference_name_does_not_match' in additional_checks %}
         <table class="table">
@@ -676,8 +676,8 @@
         {% include 'cove_ofds/additional_checks_table_failure_counter.html' with list1=additional_checks.node_international_connections_country_not_set  %}
     </h4>
     <p>
-        {% trans 'Your data contains nodes with international connections that do not specify a country. `.country` must be set for each international connection in `/nodes/internationalConnections`.'  %}
-        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Node,internationalConnections">`Node.internationalConnections`</a>.
+        {% trans 'Your data contains nodes with international connections that do not specify a country. <code>.country</code> must be set for each international connection in <code>/nodes/internationalConnections</code>.'  %}
+        For more information, see <a target="_blank" href="https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html#network-schema.json,/definitions/Node,internationalConnections"><code>Node.internationalConnections</code></a>.
     </p>
     <table class="table">
         <thead>

--- a/cove_ofds/templates/cove_ofds/jsonschema_validation_panel.html
+++ b/cove_ofds/templates/cove_ofds/jsonschema_validation_panel.html
@@ -23,13 +23,13 @@
 
 {% if 'Fieldnamedoesnotmatchpattern' in validation_errors %}
     <h4>{% trans 'Field name does not match pattern' %}</h4>
-    <p>You must ensure that fields in `Node.location` and `Span.route` are not named 'properties' or 'nodes'.</p>
+    <p>You must ensure that fields in <code>Node.location</code> and <code>Span.route</code> are not named 'properties' or 'nodes'.</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Fieldnamedoesnotmatchpattern error_table_id="Fieldnamedoesnotmatchpattern" %}
 {% endif %}
 
 {% if 'Valuedoesnotmatchpattern' in validation_errors %}
     <h4>{% trans 'Value does not match pattern' %}</h4>
-    <p>You must ensure that only the first item in the `links` array has `.rel` set to 'describedBy`.</p>
+    <p>You must ensure that only the first item in the <code>links</code> array has <code>.rel</code> set to <code>describedBy</code>.</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Fieldnamedoesnotmatchpattern col_instance=True error_table_id="Fieldnamedoesnotmatchpattern" %}
 {% endif %}
 
@@ -50,7 +50,7 @@
 
 {% if 'Valueisnotaboolean' in validation_errors %}
     <h4>{% trans 'Value is not a boolean' %}</h4>
-    <p>You must ensure that each value is either `true` or `false`. You should check that values are not enclosed in qoute characters (`"`).</p>
+    <p>You must ensure that each value is either <code>true</code> or <code>false</code>. You should check that values are not enclosed in qoute characters (<code>"</code>).</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotaboolean col_instance=True error_table_id="Valueisnotaboolean" %}
 {% endif %}
 
@@ -58,8 +58,8 @@
 {% if 'Valueisnotaninteger' in validation_errors %}
     <h4>{% trans 'Value is not an integer' %}</h4>
     <p>
-        You must ensure that each value contains only digits (`0-9`) and, optionally, the dot character (`.`). Integer values must have either no fractional part (e.g. `1`) or a zero fractional part (e.g. `1.0`).
-        You should check that values are not enclosed in quote characters, e.g. `1` is an integer, but `"1"` is a string.
+        You must ensure that each value contains only digits (<code>0-9</code>) and, optionally, the dot character (<code>.</code>). Integer values must have either no fractional part (e.g. <code>1</code>) or a zero fractional part (e.g. <code>1.0</code>).
+        You should check that values are not enclosed in quote characters, e.g. <code>1</code> is an integer, but <code>"1"</code> is a string.
     </p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotaninteger col_instance=True error_table_id="Valueisnotaninteger" %}
 {% endif %}
@@ -67,28 +67,28 @@
 
 {% if 'Valueisnotanumber' in validation_errors %}
     <h4>{% trans 'Value is not a number' %}</h4>
-    <p>You must ensure that each value contains only digits (`0-9`) and, optionally, the dot character (`.`). You should check that values are not enclosed in quote characters, e.g. `1` is an integer, but `"1"` is a string.</p>
+    <p>You must ensure that each value contains only digits (<code>0-9</code>) and, optionally, the dot character (<code>.</code>). You should check that values are not enclosed in quote characters, e.g. <code>1</code> is an integer, but <code>"1"</code> is a string.</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotanumber col_instance=True error_table_id="Valueisnotanumber" %}
 {% endif %}
 
 
 {% if 'Valueisnotastring' in validation_errors %}
     <h4>{% trans 'Value is not a string' %}</h4>
-    <p>You must ensure that each value begins and ends with the quote character (`"`) and that any quotes within the value are escaped with a backslash (`\`).</p>
+    <p>You must ensure that each value begins and ends with the quote character (<code>"</code>) and that any quotes within the value are escaped with a backslash (<code>\</code>).</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotastring col_instance=True error_table_id="Valueisnotastring" %}
 {% endif %}
 
 
 {% if 'Valueisnotanobject' in validation_errors %}
     <h4>{% trans 'Value is not an object' %}</h4>
-    <p>You must ensure that each value is enclosed in curly braces (`{` and `}`) and contains only key/value pairs.</p>
+    <p>You must ensure that each value is enclosed in curly braces (<code>{</code> and <code>}</code>) and contains only key/value pairs.</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotanobject col_instance=True error_table_id="Valueisnotanobject" %}
 {% endif %}
 
 
 {% if 'Valueisnotanarray' in validation_errors %}
     <h4>{% trans 'Value is not an array' %}</h4>
-    <p>You must ensure that each value is enclosed in square brackets (`[` and `]`).</p>
+    <p>You must ensure that each value is enclosed in square brackets (<code>[</code> and <code>]</code>).</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Valueisnotanarray col_instance=True error_table_id="Valueisnotanarray" %}
 {% endif %}
 
@@ -109,7 +109,7 @@
 
 {% if 'Incorrectlyformatteddate' in validation_errors %}
     <h4>{% trans 'Incorrectly formatted date' %}</h4>
-    <p>You must ensure that each date is in `"YYYY-MM-DD"` format.</p>
+    <p>You must ensure that each date is in <code>"YYYY-MM-DD"</code> format.</p>
     {% include "cove_ofds/jsonschema_validation_table.html" with validation_errors_for_table=validation_errors.Incorrectlyformatteddate col_instance=True error_table_id="Incorrectlyformatteddate" %}
 {% endif %}
 


### PR DESCRIPTION
## Summary
Render words surrounded by `` ` ``backticks`` ` `` as `code`

Fixes: https://github.com/Open-Telecoms-Data/cove-ofds/issues/35

## Verify
1. Upload some invalid JSON
2. In the 'Structure and Format' section, ensure code is rendered as `code`