### PR TITLE
Upgrade CI - Python versions, github actions versions, remove old cache

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -12,21 +12,15 @@ jobs:
         key: ${{ secrets.DOKKUSD_BRANCH_SSH_PRIVATE_KEY }}
         name: id_rsa # optional
         known_hosts: ${{ secrets.DOKKUSD_BRANCH_SSH_KEYSCAN }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.7
+        python-version: 3.12
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - run: pip install dokkusd
     - uses: oNaiPs/secrets-to-env-action@v1
       with:

--- a/.github/workflows/branch-destroy.yml
+++ b/.github/workflows/branch-destroy.yml
@@ -13,16 +13,10 @@ jobs:
         name: id_rsa # optional
         known_hosts: ${{ secrets.DOKKUSD_BRANCH_SSH_KEYSCAN }}
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.7
+        python-version: 3.12
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - run: pip install dokkusd
     - run: python -m dokkusd.cli destroy --appname ${{ secrets.DOKKUSD_BRANCH_APP_NAME_PREFIX }}-${{ github.event.ref }}
       env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,18 +5,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
+        # Match live server, version set in Dockerfile
         python-version: 3.9
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - run: pip install -r requirements_dev.txt
     - run: isort --check-only cove_project/ cove_ofds/
     - run: black --check cove_project/ cove_ofds/

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -13,21 +13,15 @@ jobs:
         key: ${{ secrets.DOKKUSD_LIVE_SSH_PRIVATE_KEY }}
         name: id_rsa # optional
         known_hosts: ${{ secrets.DOKKUSD_LIVE_SSH_KEYSCAN }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.7
+        python-version: 3.12
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - run: pip install dokkusd
     - uses: oNaiPs/secrets-to-env-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,22 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Match live server
+        # Match live server, version set in Dockerfile
         python-version: [ '3.9']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
     - name: Install requirements_dev.txt
       run: pip install -r requirements_dev.txt
     - name: Test


### PR DESCRIPTION
3.12 used for dokku work as that is latest version dokkusd is tested with